### PR TITLE
CVSB-17698 - retry errors up to X times or until message expires

### DIFF
--- a/src/functions/edhMarshaller.ts
+++ b/src/functions/edhMarshaller.ts
@@ -32,7 +32,7 @@ const edhMarshaller: Handler = async (event: GetRecordsOutput, context?: Context
 
     records.forEach((record: StreamRecord) => {
         debugOnlyLog("Record: ", record);
-        debugOnlyLog("New image: ", record.dynamodb?.NewImage)
+        debugOnlyLog("New image: ", record.dynamodb?.NewImage);
         const targetQueue = getTargetQueueFromSourceARN(record.eventSourceARN);
         debugOnlyLog("Target Queue", targetQueue);
         const eventType = record.eventName; //INSERT, MODIFY or REMOVE
@@ -49,9 +49,8 @@ const edhMarshaller: Handler = async (event: GetRecordsOutput, context?: Context
         console.error(error);
         console.log("records");
         console.log(records);
-        if(error.code !== "InvalidParameterValue"){
-            throw error;
-        }
+        // Lambda will retry up to X times or until the message expires, after which the message will be sent to the dlq.
+        throw error;
     });
 };
 

--- a/tests/unit/edhMarshallerFunction.unitTest.ts
+++ b/tests/unit/edhMarshallerFunction.unitTest.ts
@@ -1,5 +1,4 @@
 import {edhMarshaller} from "../../src/functions/edhMarshaller";
-import mockContext from "aws-lambda-mock-context";
 import {SQService} from "../../src/services/SQService";
 import {Configuration} from "../../src/utils/Configuration";
 import {Context} from "aws-lambda";


### PR DESCRIPTION
This ticket covers the work required to fix EDH marshaller lambda which sometimes fails when the payload is too big (It returns 413 errors)

If the lambda fails to process the message and throws an error, then it will log the error and it will retry up to X times (configurable from AWS, currently set to 3 times) or until the message expires (60 seconds), after which it will send the message to the respective DLQs for further investigation.

https://jira.dvsacloud.uk/browse/CVSB-17698