### PR TITLE
fix(cb2-7666): Cannot amend Tech Record with frontVehicleTo5thWheelCouplingMax or Min

### DIFF
--- a/tests/unit/utils/transform-tech-record.test.ts
+++ b/tests/unit/utils/transform-tech-record.test.ts
@@ -322,10 +322,10 @@ const dbRecordOld: DynamoDBRecord = {
               'euroStandard': {
                 'S': '7',
               },
-              'frontAxleTo5thWheelCouplingMax': {
+              'frontVehicleTo5thWheelCouplingMax': {
                 'N': '1900',
               },
-              'frontAxleTo5thWheelCouplingMin': {
+              'frontVehicleTo5thWheelCouplingMin': {
                 'N': '1700',
               },
               'frontAxleTo5thWheelMax': {
@@ -663,10 +663,10 @@ const dbRecordNew: DynamoDBRecord = {
       'techRecord_euroStandard': {
         'S': '7',
       },
-      'techRecord_frontAxleTo5thWheelCouplingMax': {
+      'techRecord_frontVehicleTo5thWheelCouplingMax': {
         'N': '1900',
       },
-      'techRecord_frontAxleTo5thWheelCouplingMin': {
+      'techRecord_frontVehicleTo5thWheelCouplingMin': {
         'N': '1700',
       },
       'techRecord_frontAxleTo5thWheelMax': {


### PR DESCRIPTION
Cannot amend Tech Record with frontVehicleTo5thWheelCouplingMax or Min

Global find and replace of AxleTo5thWheelCoupling -> VehicleTo5thWheelCoupling

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-7666)

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number