### PR TITLE
CB2-7804: EDH-Marshaller lambda function times out before SQS requests

### DIFF
--- a/src/functions/edh-marshaller.ts
+++ b/src/functions/edh-marshaller.ts
@@ -44,6 +44,9 @@ const edhMarshaller: Handler = async (event: DynamoDBStreamEvent): Promise<Batch
       new SQS({
         region: 'eu-west-1',
         apiVersion: '2012-11-05',
+        httpOptions: {
+          timeout: 5000,
+        },
       }),
     );
   }
@@ -68,7 +71,8 @@ const edhMarshaller: Handler = async (event: DynamoDBStreamEvent): Promise<Batch
     sendMessagePromises.push(
       sqs.sendMessage(params).promise()
         .then(() => debugOnlyLog('Succesfully sent SQS message'))
-        .catch(() => {
+        .catch((err) => {
+          console.error(JSON.stringify(err));
           console.error(`Failed to push SQS message for record: ${JSON.stringify(record)}`);
           res.batchItemFailures.push({ itemIdentifier: id });
         }),


### PR DESCRIPTION
## Change

Reduce the SQS request timeout so the function does not timeout first.

## Why

If there is an issue with anyone of the SQS requests, the function will timeout and the whole batch of records will be retried. Reducing the SQS timeout means the function will fail faster and only the failed records will be retired. More details can be found in the ticket [CB2-7804](https://dvsa.atlassian.net/browse/CB2-7804).
